### PR TITLE
Changes to make it compatible with expo

### DIFF
--- a/ClusterMarker.js
+++ b/ClusterMarker.js
@@ -3,8 +3,10 @@
 // base libs
 import PropTypes from 'prop-types'
 import React, { Component } from 'react'
-import { Marker } from 'react-native-maps'
+import { MapView } from 'expo'
 import { Text, View, StyleSheet } from 'react-native'
+
+const Marker = MapView.Marker
 
 export default class ClusterMarker extends Component {
   constructor(props) {

--- a/ClusteredMapView.js
+++ b/ClusteredMapView.js
@@ -9,7 +9,7 @@ import {
   LayoutAnimation
 } from 'react-native'
 // map-related libs
-import MapView from 'react-native-maps'
+import { MapView } from 'expo'
 import SuperCluster from 'supercluster'
 import GeoViewport from '@mapbox/geo-viewport'
 // components / views

--- a/README.md
+++ b/README.md
@@ -1,5 +1,5 @@
 # React Native Super Cluster
-This module wraps [AirBnB's react-native-maps](https://github.com/airbnb/react-native-maps) and uses [MapBox's SuperCluster](https://github.com/mapbox/supercluster) as clustering engine.
+This module wraps [AirBnB's react-native-maps](https://github.com/airbnb/react-native-maps) and uses [MapBox's SuperCluster](https://github.com/mapbox/supercluster) as clustering engine. **This version of the package ONLY works with Expo**
 
 ## Example
 


### PR DESCRIPTION
Expo uses the maps package differently (it exports the MapView package from the expo package), and when you try to use this package, you get an error because you're creating components twice (one from expo, one from you using react-native-maps), so i changed the dependencies that you used. **I recommend creating a branch for this**