### PR TITLE
fix crash when cross the dateline - handle negative longitudeDelta

### DIFF
--- a/util.js
+++ b/util.js
@@ -5,12 +5,18 @@
  * @param {Object} region - Google Maps/MapKit region
  * @returns {Object} - Region's bounding box as WSEN array
  */
-export const regionToBoundingBox = (region) => ([
-  region.longitude - region.longitudeDelta, // westLng - min lng
-  region.latitude - region.latitudeDelta, // southLat - min lat
-  region.longitude + region.longitudeDelta, // eastLng - max lng
-  region.latitude + region.latitudeDelta // northLat - max lat
-])
+export const regionToBoundingBox = (region) => {
+      let lngD;
+      if(region.longitudeDelta < 0)
+          lngD = region.longitudeDelta + 360
+      else
+          lngD = region.longitudeDelta;     
+      return([
+      region.longitude - lngD, // westLng - min lng
+      region.latitude - region.latitudeDelta, // southLat - min lat
+      region.longitude + lngD, // eastLng - max lng
+      region.latitude + region.latitudeDelta // northLat - max lat
+    ])}
 
 /**
  * Calculate region from the given bounding box.


### PR DESCRIPTION
fixes issue #20 see details.
not tested for actual markers on the dateline, but stops app from crashing when cross the dateline