### PR TITLE
fix stale region data when drawing clusters

### DIFF
--- a/ClusteredMapView.js
+++ b/ClusteredMapView.js
@@ -85,9 +85,12 @@ export default class ClusteredMapView extends PureComponent {
     let data
     if (region.longitudeDelta <= 80) {
       data = this.getClusters(region)
-      this.setState({ region, data })
+      this.setState({ region, data }, () => {
+        this.props.onRegionChangeComplete && this.props.onRegionChangeComplete(region, data)
+      })
+    } else {
+      this.props.onRegionChangeComplete && this.props.onRegionChangeComplete(region, data)
     }
-    this.props.onRegionChangeComplete && this.props.onRegionChangeComplete(region, data)
   }
 
   getClusters = (region) => {


### PR DESCRIPTION
In `ClusteredMapView`, `clusterize` is called on every component change and takes region data from state. However, the `onRegionChangeComplete` handler (which gets freshest data from MapView) calls both setState _and_ `this.props.onRegionChangeComplete`, which may trigger component's re-render. 

Because `this.props.onRegionChangeComplete` is called before React state is updated (setState is async), `clusterize` gets stale data in cases when `this.props.onRegionChangeComplete` causes a re-render. 

This PR fixes it by waiting for state update before calling `this.props.onRegionChangeComplete` which causes re-render of the component with updated data.