### PR TITLE
Bugfix: Remove limit of longitude delta 80 from onRegionChangeComplete

### DIFF
--- a/ClusteredMapView.js
+++ b/ClusteredMapView.js
@@ -81,15 +81,10 @@ export default class ClusteredMapView extends PureComponent {
   clustersChanged = (nextState) => this.state.data.length !== nextState.data.length
 
   onRegionChangeComplete = (region) => {
-    let data
-    if (region.longitudeDelta <= 80) {
-      data = this.getClusters(region)
-      this.setState({ region, data }, () => {
+    let data = this.getClusters(region);
+    this.setState({ region, data }, () => {
         this.props.onRegionChangeComplete && this.props.onRegionChangeComplete(region, data)
-      })
-    } else {
-      this.props.onRegionChangeComplete && this.props.onRegionChangeComplete(region, data)
-    }
+    })
   }
 
   getClusters = (region) => {


### PR DESCRIPTION
The onRegionChangeComplete method does not call 

`this.setState({ region, data }`

If the longitude delta is > 80. 

This may result in a map that is missing clusters and markers.

Consider the following case:
- Map starts out at a small region, let's say Italy
- I am calling fitToCoordinates on the underlying mapView, with coordinates that are spread all over the world - example, San Francisco, Bangkok, Australia. 
- The map now correctly fits these coordinates, it's all the way zoomed out.
- this.state.data is now still set to the clusters that were there around Italy
- onRegionChangeComplete does not change this.state.data because long delta is > 80
- this.state.data therefore does not contain any data on map points in San Francisco, Bangkok, or Austraila
- Map appears empty
- Data points only appear when zooming in such that long delta is <= 80

Fix: 
Remove arbitrary-seeming limit of the long delta. This is clearly a bug. Submitting PR, which I tested with the above data. 

Cheers! :) 