### PR TITLE
Passing location as a number

### DIFF
--- a/ClusteredMapView.js
+++ b/ClusteredMapView.js
@@ -110,7 +110,13 @@ export default class ClusteredMapView extends PureComponent {
           markers = children.map(c => c.properties.item)
 
     // fit right around them, considering edge padding
-    this.mapview.fitToCoordinates(markers.map(m => m.location), { edgePadding: this.props.edgePadding })
+    this.mapview.fitToCoordinates(
+      markers.map(m => ({
+        latitude: +m.location.latitude,
+        longitude: +m.location.longitude
+      })),
+      { edgePadding: this.props.edgePadding }
+    );
 
     this.props.onClusterPress && this.props.onClusterPress(cluster.properties.cluster_id, markers)
   }


### PR DESCRIPTION
Library is working great, Thanks for all the effort.

Can't get onPress a map cluster to work on android, had to cast the location parameters numbers for it to work. And use a custom forked repo for it to work.

Notes:
- It works just fine on ios with or without my modification.
- Error message will be attached before modifications (on Android).
- On apple maps when I zoom out far enough rendered clusters/pins disappear. (seems to work just fine on android *google maps*)
https://user-images.githubusercontent.com/42909451/52913939-6d005900-32cb-11e9-9ce6-18f9fbe86014.png
