### PR TITLE
Fix flickering clusters

### DIFF
--- a/ClusteredMapView.js
+++ b/ClusteredMapView.js
@@ -195,5 +195,5 @@ ClusteredMapView.propTypes = {
   edgePadding: PropTypes.object.isRequired,
   // string
   // mutiple
-  accessor: PropTypes.oneOf([PropTypes.string, PropTypes.func])
+  accessor: PropTypes.oneOfType([PropTypes.string, PropTypes.func])
 }

--- a/README.md
+++ b/README.md
@@ -106,7 +106,7 @@ export default class MyClusteredMapView extends Component {
 radius | Number | false | window width * 4,5% | [SuperCluster radius](https://github.com/mapbox/supercluster#options).
 extent | Number | false | 512 | [SuperCluster extent](https://github.com/mapbox/supercluster#options).
 minZoom | Number | false | 1 | [SuperCluster minZoom](https://github.com/mapbox/supercluster#options).
-maxZoom | Number | false | 20 | [SuperCluster maxZoom](https://github.com/mapbox/supercluster#options).
+maxZoom | Number | false | 16 | [SuperCluster maxZoom](https://github.com/mapbox/supercluster#options).
 width | Number | false | window width | map's width.
 height | Number | false | window height | map's height.
 data | Array <Object> | true | undefined | Objects must have an attribute `location` representing a `GeoPoint`, i.e. `{ latitude: x, longitude: y }`.


### PR DESCRIPTION
I wrote a method that preserves same cluster key across region changes, i.e. SuperCluster engine computes clusters every time region changes and rerenders all clusters even though some of them did not change at all (same coordinates, same point count). Rerendering is triggered by generating new cluster_id which is then passed to cluster component key.