### PR TITLE
Flickering clusters

### DIFF
--- a/ClusteredMapView.js
+++ b/ClusteredMapView.js
@@ -63,6 +63,32 @@ export default class ClusteredMapView extends PureComponent {
   getClusteringEngine() {
     return this.index
   }
+  
+  clustersComparator = ({
+      geometry: { coordinates: c1 },
+      properties: { point_count: pc1 }
+  }) => ({
+      geometry: { coordinates: c2 },
+      properties: { point_count: pc2 }
+  }) => {
+      return (
+          pc1 === pc2 &&
+          Math.abs(c1[0] - c2[0]) < Number.EPSILON &&
+          Math.abs(c1[1] - c2[1]) < Number.EPSILON
+      );
+  };
+
+  preserveUnchangedClusterIds(data) {
+    const prevClusters = this.state.data.filter(d => d.properties.cluster);
+    data.filter(d => d.properties.cluster).forEach(cluster => {
+        const comparator = this.clustersComparator(cluster);
+        const item = prevClusters.find(comparator);
+        if (item) {
+            cluster.properties.cluster_id = item.properties.cluster_id;
+        }
+    });
+    return data;
+}
 
   clusterize(dataset) {
     this.index = new SuperCluster({ // eslint-disable-line new-cap
@@ -78,7 +104,7 @@ export default class ClusteredMapView extends PureComponent {
     // load geopoints into SuperCluster
     this.index.load(rawData)
 
-    const data = this.getClusters(this.state.region)
+    const data = this.preserveUnchangedClusterIds(this.getClusters(this.state.region));
     this.setState({ data })
   }
 
@@ -87,7 +113,7 @@ export default class ClusteredMapView extends PureComponent {
   }
 
   onRegionChangeComplete(region) {
-    let data = this.getClusters(region)
+    let data = this.preserveUnchangedClusterIds(this.getClusters(region));
     this.setState({ region, data }, () => {
         this.props.onRegionChangeComplete && this.props.onRegionChangeComplete(region, data)
     })

--- a/ClusteredMapView.js
+++ b/ClusteredMapView.js
@@ -116,7 +116,7 @@ export default class ClusteredMapView extends PureComponent {
           markers = children.map(c => c.properties.item)
 
     // fit right around them, considering edge padding
-    this.mapview.fitToCoordinates(markers.map(m => m.location), { edgePadding: this.props.edgePadding })
+    this.mapview.fitToCoordinates(markers.map(m => m[this.props.accessor]), { edgePadding: this.props.edgePadding })
 
     this.props.onClusterPress && this.props.onClusterPress(cluster.properties.cluster_id, markers)
   }


### PR DESCRIPTION
I wrote a method that preserves same cluster key across region changes, i.e. SuperCluster engine computes clusters every time region changes and rerenders all clusters even though some of them did not change at all (same coordinates, same point count). Rerendering is triggered by generating new cluster_id which is then passed to cluster component key.