### PR TITLE
Remove outdated lifecycle methods

### DIFF
--- a/ClusteredMapView.js
+++ b/ClusteredMapView.js
@@ -1,158 +1,168 @@
-'use-strict'
+"use-strict";
 
 // base libs
-import PropTypes from 'prop-types'
-import React, { PureComponent } from 'react'
-import {
-  Platform,
-  Dimensions,
-  LayoutAnimation
-} from 'react-native'
+import PropTypes from "prop-types";
+import React, { PureComponent } from "react";
+import { Platform, Dimensions, LayoutAnimation } from "react-native";
 // map-related libs
-import MapView from 'react-native-maps'
-import SuperCluster from 'supercluster'
-import GeoViewport from '@mapbox/geo-viewport'
+import MapView from "react-native-maps";
+import SuperCluster from "supercluster";
+import GeoViewport from "@mapbox/geo-viewport";
 // components / views
-import ClusterMarker from './ClusterMarker'
+import ClusterMarker from "./ClusterMarker";
 // libs / utils
 import {
   regionToBoundingBox,
   itemToGeoJSONFeature,
-  getCoordinatesFromItem,
-} from './util'
+  getCoordinatesFromItem
+} from "./util";
 
 export default class ClusteredMapView extends PureComponent {
-
   constructor(props) {
-    super(props)
+    super(props);
 
     this.state = {
       data: [], // helds renderable clusters and markers
-      region: props.region || props.initialRegion, // helds current map region
-    }
+      region: props.region || props.initialRegion // helds current map region
+    };
 
-    this.isAndroid = Platform.OS === 'android'
-    this.dimensions = [props.width, props.height]
+    this.isAndroid = Platform.OS === "android";
+    this.dimensions = [props.width, props.height];
 
-    this.mapRef = this.mapRef.bind(this)
-    this.onClusterPress = this.onClusterPress.bind(this)
-    this.onRegionChangeComplete = this.onRegionChangeComplete.bind(this)
+    this.mapRef = this.mapRef.bind(this);
+    this.onClusterPress = this.onClusterPress.bind(this);
+    this.onRegionChangeComplete = this.onRegionChangeComplete.bind(this);
   }
 
   componentDidMount() {
-    this.clusterize(this.props.data)
+    this.clusterize(this.props.data);
   }
 
-  componentWillReceiveProps(nextProps) {
-    if (this.props.data !== nextProps.data)
-      this.clusterize(nextProps.data)
-  }
-
-  componentWillUpdate(nextProps, nextState) {
-    if (!this.isAndroid && this.props.animateClusters && this.clustersChanged(nextState))
-      LayoutAnimation.configureNext(this.props.layoutAnimationConf)
+  componentDidUpdate(prevProps) {
+    if (this.props.data !== prevProps.data) this.clusterize(this.props.data);
+    if (
+      !this.isAndroid &&
+      this.props.animateClusters &&
+      this.clustersChanged(this.state)
+    )
+      LayoutAnimation.configureNext(this.props.layoutAnimationConf);
   }
 
   mapRef(ref) {
-    this.mapview = ref
+    this.mapview = ref;
   }
 
   getMapRef() {
-    return this.mapview
+    return this.mapview;
   }
 
   getClusteringEngine() {
-    return this.index
+    return this.index;
   }
 
   clusterize(dataset) {
-    this.index = new SuperCluster({ // eslint-disable-line new-cap
+    this.index = new SuperCluster({
+      // eslint-disable-line new-cap
       extent: this.props.extent,
       minZoom: this.props.minZoom,
       maxZoom: this.props.maxZoom,
-      radius: this.props.radius || (this.dimensions[0] * .045), // 4.5% of screen width
-    })
+      radius: this.props.radius || this.dimensions[0] * 0.045 // 4.5% of screen width
+    });
 
     // get formatted GeoPoints for cluster
-    const rawData = dataset.map(item => itemToGeoJSONFeature(item, this.props.accessor))
+    const rawData = dataset.map(item =>
+      itemToGeoJSONFeature(item, this.props.accessor)
+    );
 
     // load geopoints into SuperCluster
-    this.index.load(rawData)
+    this.index.load(rawData);
 
-    const data = this.getClusters(this.state.region)
-    this.setState({ data })
+    const data = this.getClusters(this.state.region);
+    this.setState({ data });
   }
 
   clustersChanged(nextState) {
-    return this.state.data.length !== nextState.data.length
+    return this.state.data.length !== nextState.data.length;
   }
 
   onRegionChangeComplete(region) {
-    let data = this.getClusters(region)
+    let data = this.getClusters(region);
     this.setState({ region, data }, () => {
-        this.props.onRegionChangeComplete && this.props.onRegionChangeComplete(region, data)
-    })
+      this.props.onRegionChangeComplete &&
+        this.props.onRegionChangeComplete(region, data);
+    });
   }
 
   getClusters(region) {
     const bbox = regionToBoundingBox(region),
-          viewport = (region.longitudeDelta) >= 40 ? { zoom: this.props.minZoom } : GeoViewport.viewport(bbox, this.dimensions)
+      viewport =
+        region.longitudeDelta >= 40
+          ? { zoom: this.props.minZoom }
+          : GeoViewport.viewport(bbox, this.dimensions);
 
-    return this.index.getClusters(bbox, viewport.zoom)
+    return this.index.getClusters(bbox, viewport.zoom);
   }
 
   onClusterPress(cluster) {
-
     // cluster press behavior might be extremely custom.
     if (!this.props.preserveClusterPressBehavior) {
-      this.props.onClusterPress && this.props.onClusterPress(cluster.properties.cluster_id)
-      return
+      this.props.onClusterPress &&
+        this.props.onClusterPress(cluster.properties.cluster_id);
+      return;
     }
 
     // //////////////////////////////////////////////////////////////////////////////////
     // NEW IMPLEMENTATION (with fitToCoordinates)
     // //////////////////////////////////////////////////////////////////////////////////
     // get cluster children
-    const children = this.index.getLeaves(cluster.properties.cluster_id, this.props.clusterPressMaxChildren)
-    const markers = children.map(c => c.properties.item)
+    const children = this.index.getLeaves(
+      cluster.properties.cluster_id,
+      this.props.clusterPressMaxChildren
+    );
+    const markers = children.map(c => c.properties.item);
 
-    const coordinates = markers.map(item => getCoordinatesFromItem(item, this.props.accessor, false))
+    const coordinates = markers.map(item =>
+      getCoordinatesFromItem(item, this.props.accessor, false)
+    );
 
     // fit right around them, considering edge padding
-    this.mapview.fitToCoordinates(coordinates, { edgePadding: this.props.edgePadding })
+    this.mapview.fitToCoordinates(coordinates, {
+      edgePadding: this.props.edgePadding
+    });
 
-    this.props.onClusterPress && this.props.onClusterPress(cluster.properties.cluster_id, markers)
+    this.props.onClusterPress &&
+      this.props.onClusterPress(cluster.properties.cluster_id, markers);
   }
 
   render() {
-    const { style, ...props } = this.props
+    const { style, ...props } = this.props;
 
     return (
       <MapView
         {...props}
         style={style}
         ref={this.mapRef}
-        onRegionChangeComplete={this.onRegionChangeComplete}>
-        {
-          this.props.clusteringEnabled && this.state.data.map((d) => {
+        onRegionChangeComplete={this.onRegionChangeComplete}
+      >
+        {this.props.clusteringEnabled &&
+          this.state.data.map(d => {
             if (d.properties.point_count === 0)
-              return this.props.renderMarker(d.properties.item)
+              return this.props.renderMarker(d.properties.item);
 
             return (
               <ClusterMarker
                 {...d}
                 onPress={this.onClusterPress}
                 renderCluster={this.props.renderCluster}
-                key={`cluster-${d.properties.cluster_id}`} />
-            )
-          })
-        }
-        {
-          !this.props.clusteringEnabled && this.props.data.map(d => this.props.renderMarker(d))
-        }
+                key={`cluster-${d.properties.cluster_id}`}
+              />
+            );
+          })}
+        {!this.props.clusteringEnabled &&
+          this.props.data.map(d => this.props.renderMarker(d))}
         {this.props.children}
       </MapView>
-    )
+    );
   }
 }
 
@@ -160,16 +170,16 @@ ClusteredMapView.defaultProps = {
   minZoom: 1,
   maxZoom: 16,
   extent: 512,
-  accessor: 'location',
+  accessor: "location",
   animateClusters: true,
   clusteringEnabled: true,
   clusterPressMaxChildren: 100,
   preserveClusterPressBehavior: true,
-  width: Dimensions.get('window').width,
-  height: Dimensions.get('window').height,
+  width: Dimensions.get("window").width,
+  height: Dimensions.get("window").height,
   layoutAnimationConf: LayoutAnimation.Presets.spring,
   edgePadding: { top: 10, left: 10, right: 10, bottom: 10 }
-}
+};
 
 ClusteredMapView.propTypes = {
   ...MapView.propTypes,
@@ -199,4 +209,4 @@ ClusteredMapView.propTypes = {
   // string
   // mutiple
   accessor: PropTypes.oneOfType([PropTypes.string, PropTypes.func])
-}
+};

--- a/ClusteredMapView.js
+++ b/ClusteredMapView.js
@@ -1,41 +1,46 @@
-"use-strict";
+'use-strict'
 
 // base libs
-import PropTypes from "prop-types";
-import React, { PureComponent } from "react";
-import { Platform, Dimensions, LayoutAnimation } from "react-native";
+import PropTypes from 'prop-types'
+import React, { PureComponent } from 'react'
+import {
+  Platform,
+  Dimensions,
+  LayoutAnimation
+} from 'react-native'
 // map-related libs
-import MapView from "react-native-maps";
-import SuperCluster from "supercluster";
-import GeoViewport from "@mapbox/geo-viewport";
+import MapView from 'react-native-maps'
+import SuperCluster from 'supercluster'
+import GeoViewport from '@mapbox/geo-viewport'
 // components / views
-import ClusterMarker from "./ClusterMarker";
+import ClusterMarker from './ClusterMarker'
 // libs / utils
 import {
   regionToBoundingBox,
   itemToGeoJSONFeature,
-  getCoordinatesFromItem
-} from "./util";
+  getCoordinatesFromItem,
+} from './util'
 
 export default class ClusteredMapView extends PureComponent {
+
   constructor(props) {
-    super(props);
+    super(props)
 
     this.state = {
       data: [], // helds renderable clusters and markers
-      region: props.region || props.initialRegion // helds current map region
-    };
+      region: props.region || props.initialRegion, // helds current map region
+    }
 
-    this.isAndroid = Platform.OS === "android";
-    this.dimensions = [props.width, props.height];
+    this.isAndroid = Platform.OS === 'android'
+    this.dimensions = [props.width, props.height]
 
-    this.mapRef = this.mapRef.bind(this);
-    this.onClusterPress = this.onClusterPress.bind(this);
-    this.onRegionChangeComplete = this.onRegionChangeComplete.bind(this);
+    this.mapRef = this.mapRef.bind(this)
+    this.onClusterPress = this.onClusterPress.bind(this)
+    this.onRegionChangeComplete = this.onRegionChangeComplete.bind(this)
   }
 
   componentDidMount() {
-    this.clusterize(this.props.data);
+    this.clusterize(this.props.data)
   }
 
   componentDidUpdate(prevProps) {
@@ -48,121 +53,107 @@ export default class ClusteredMapView extends PureComponent {
       LayoutAnimation.configureNext(this.props.layoutAnimationConf);
   }
 
+
   mapRef(ref) {
-    this.mapview = ref;
+    this.mapview = ref
   }
 
   getMapRef() {
-    return this.mapview;
+    return this.mapview
   }
 
   getClusteringEngine() {
-    return this.index;
+    return this.index
   }
 
   clusterize(dataset) {
-    this.index = new SuperCluster({
-      // eslint-disable-line new-cap
+    this.index = new SuperCluster({ // eslint-disable-line new-cap
       extent: this.props.extent,
       minZoom: this.props.minZoom,
       maxZoom: this.props.maxZoom,
-      radius: this.props.radius || this.dimensions[0] * 0.045 // 4.5% of screen width
-    });
+      radius: this.props.radius || (this.dimensions[0] * .045), // 4.5% of screen width
+    })
 
     // get formatted GeoPoints for cluster
-    const rawData = dataset.map(item =>
-      itemToGeoJSONFeature(item, this.props.accessor)
-    );
+    const rawData = dataset.map(item => itemToGeoJSONFeature(item, this.props.accessor))
 
     // load geopoints into SuperCluster
-    this.index.load(rawData);
+    this.index.load(rawData)
 
-    const data = this.getClusters(this.state.region);
-    this.setState({ data });
+    const data = this.getClusters(this.state.region)
+    this.setState({ data })
   }
 
   clustersChanged(nextState) {
-    return this.state.data.length !== nextState.data.length;
+    return this.state.data.length !== nextState.data.length
   }
 
   onRegionChangeComplete(region) {
-    let data = this.getClusters(region);
+    let data = this.getClusters(region)
     this.setState({ region, data }, () => {
-      this.props.onRegionChangeComplete &&
-        this.props.onRegionChangeComplete(region, data);
-    });
+        this.props.onRegionChangeComplete && this.props.onRegionChangeComplete(region, data)
+    })
   }
 
   getClusters(region) {
     const bbox = regionToBoundingBox(region),
-      viewport =
-        region.longitudeDelta >= 40
-          ? { zoom: this.props.minZoom }
-          : GeoViewport.viewport(bbox, this.dimensions);
+          viewport = (region.longitudeDelta) >= 40 ? { zoom: this.props.minZoom } : GeoViewport.viewport(bbox, this.dimensions)
 
-    return this.index.getClusters(bbox, viewport.zoom);
+    return this.index.getClusters(bbox, viewport.zoom)
   }
 
   onClusterPress(cluster) {
+
     // cluster press behavior might be extremely custom.
     if (!this.props.preserveClusterPressBehavior) {
-      this.props.onClusterPress &&
-        this.props.onClusterPress(cluster.properties.cluster_id);
-      return;
+      this.props.onClusterPress && this.props.onClusterPress(cluster.properties.cluster_id)
+      return
     }
 
     // //////////////////////////////////////////////////////////////////////////////////
     // NEW IMPLEMENTATION (with fitToCoordinates)
     // //////////////////////////////////////////////////////////////////////////////////
     // get cluster children
-    const children = this.index.getLeaves(
-      cluster.properties.cluster_id,
-      this.props.clusterPressMaxChildren
-    );
-    const markers = children.map(c => c.properties.item);
+    const children = this.index.getLeaves(cluster.properties.cluster_id, this.props.clusterPressMaxChildren)
+    const markers = children.map(c => c.properties.item)
 
-    const coordinates = markers.map(item =>
-      getCoordinatesFromItem(item, this.props.accessor, false)
-    );
+    const coordinates = markers.map(item => getCoordinatesFromItem(item, this.props.accessor, false))
 
     // fit right around them, considering edge padding
-    this.mapview.fitToCoordinates(coordinates, {
-      edgePadding: this.props.edgePadding
-    });
+    this.mapview.fitToCoordinates(coordinates, { edgePadding: this.props.edgePadding })
 
-    this.props.onClusterPress &&
-      this.props.onClusterPress(cluster.properties.cluster_id, markers);
+    this.props.onClusterPress && this.props.onClusterPress(cluster.properties.cluster_id, markers)
   }
 
   render() {
-    const { style, ...props } = this.props;
+    const { style, ...props } = this.props
 
     return (
       <MapView
         {...props}
         style={style}
         ref={this.mapRef}
-        onRegionChangeComplete={this.onRegionChangeComplete}
-      >
-        {this.props.clusteringEnabled &&
-          this.state.data.map(d => {
+        onRegionChangeComplete={this.onRegionChangeComplete}>
+        {
+          this.props.clusteringEnabled && this.state.data.map((d) => {
             if (d.properties.point_count === 0)
-              return this.props.renderMarker(d.properties.item);
+              return this.props.renderMarker(d.properties.item)
 
             return (
               <ClusterMarker
                 {...d}
                 onPress={this.onClusterPress}
                 renderCluster={this.props.renderCluster}
-                key={`cluster-${d.properties.cluster_id}`}
-              />
-            );
-          })}
-        {!this.props.clusteringEnabled &&
-          this.props.data.map(d => this.props.renderMarker(d))}
+                key={`cluster-${d.properties.cluster_id}`} />
+            )
+          })
+        }
+        {
+          !this.props.clusteringEnabled && this.props.data.map(d => this.props.renderMarker(d))
+        }
         {this.props.children}
       </MapView>
-    );
+    )
   }
 }
 
@@ -170,16 +161,16 @@ ClusteredMapView.defaultProps = {
   minZoom: 1,
   maxZoom: 16,
   extent: 512,
-  accessor: "location",
+  accessor: 'location',
   animateClusters: true,
   clusteringEnabled: true,
   clusterPressMaxChildren: 100,
   preserveClusterPressBehavior: true,
-  width: Dimensions.get("window").width,
-  height: Dimensions.get("window").height,
+  width: Dimensions.get('window').width,
+  height: Dimensions.get('window').height,
   layoutAnimationConf: LayoutAnimation.Presets.spring,
   edgePadding: { top: 10, left: 10, right: 10, bottom: 10 }
-};
+}
 
 ClusteredMapView.propTypes = {
   ...MapView.propTypes,
@@ -209,4 +200,4 @@ ClusteredMapView.propTypes = {
   // string
   // mutiple
   accessor: PropTypes.oneOfType([PropTypes.string, PropTypes.func])
-};
+}


### PR DESCRIPTION
I made these changes to the MapView in my current project and everything worked as expected. That's the extent to which this has been tested. Feel free to merge this PR, but it was created to draw attention to this. As of RN 0.6, the old lifecycle methods threw warnings on our map screen and this allows them to go away.